### PR TITLE
Fix for calving overlap error

### DIFF
--- a/src/ice_model.F90
+++ b/src/ice_model.F90
@@ -468,10 +468,10 @@ subroutine unpack_ocean_ice_boundary_calved_shelf_bergs(Ice, OIB)
   !$OMP                          private(i2,j2)
   do j=jsc,jec ; do i=isc,iec ; if (G%mask2dT(i,j) > 0.0) then
     i2 = i+i_off ; j2 = j+j_off
-    if (FIA%calving(i,j)>0.0 .and. OIB%calving(i2,j2)>0.0) &
-            call SIS_error(FATAL,"Overlap in calving from snow discharge and ice shelf!")
-    FIA%calving(i,j) = US%kg_m2s_to_RZ_T*OIB%calving(i2,j2)
-    FIA%calving_hflx(i,j) = US%W_m2_to_QRZ_T*OIB%calving_hflx(i2,j2)
+    !if (FIA%calving(i,j)>0.0 .and. OIB%calving(i2,j2)>0.0) &
+    !        call SIS_error(FATAL,"Overlap in calving from snow discharge and ice shelf!")
+    FIA%calving(i,j) = FIA%calving(i,j) + US%kg_m2s_to_RZ_T*OIB%calving(i2,j2)
+    FIA%calving_hflx(i,j) = FIA%calving_hflx(i,j) + US%W_m2_to_QRZ_T*OIB%calving_hflx(i2,j2)
   endif ; enddo ; enddo
 
   if (Ice%sCS%debug) then


### PR DESCRIPTION
While frozen runoff from the land model and ice-sheet flow from MOM6 should not overlap, interpolation errors can result in the two sources contributing to the same SIS2 cell when their respective discharge is accumulated for calving. This is now allowed, and a fatal error was removed that was previously triggered when the two sources of discharge contributed to the same cell.